### PR TITLE
Add note about setting the Chrome path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,9 @@ So happy to hear you're interested in contributing! Here's a quick rundown of ho
 
 2. `go get -u -v github.com/matthewmueller/joy/...` to install the compiler from source
 
-3. `go test -v` to run all the tests
+3. Set the `GOLLY_CHROME_PATH` to the path of your Chrome executable, ex: `export GOLLY_CHROME_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"`
+
+4. `go test -v` to run all the tests
 
 **Links and tips:**
 


### PR DESCRIPTION
This adds a note to the readme about setting `GOLLY_CHROME_PATH`, which
is needed to run the tests.