### PR TITLE
Small fixes for windows

### DIFF
--- a/internal/mains/mains.go
+++ b/internal/mains/mains.go
@@ -33,13 +33,13 @@ func Find(packages ...string) (mains []string, err error) {
 
 	for i, pkg := range packages {
 		// no prefix
-		if pkg[0] != '.' && pkg[0] != filepath.Separator {
+		if pkg[0] != '.' && !filepath.IsAbs(pkg) {
 			packages[i] = "." + string(filepath.Separator) + pkg
 			continue
 		}
 
 		// absolute
-		if pkg[0] == filepath.Separator {
+		if filepath.IsAbs(pkg) {
 			rel, err := filepath.Rel(cwd, pkg)
 			if err != nil {
 				return mains, errors.Wrapf(err, "unable to get relative path")
@@ -84,7 +84,7 @@ func Find(packages ...string) (mains []string, err error) {
 			if parts[1] == "command-line-arguments" {
 				// TODO: i don't think this will work for multiple files
 				for _, pkg := range packages {
-					results = append(results, path.Join(cwd, path.Dir(pkg)))
+					results = append(results, path.Join(cwd, filepath.Dir(pkg)))
 				}
 				continue
 			}


### PR DESCRIPTION
Because windows uses a different filesystem, it's better to use the filepath package, I am sure there is more problems, but this fix will at least make joy work.

There is a few more windows related issues I have found.

 * The relative method https://github.com/matthewmueller/joy/blob/master/internal/mains/mains.go#L43 will not work when you have Go installed on a different disk then the file you are compiling on. In my case I have Golang installed on my D: drive and I was trying to compile a file in the tmp folder which is on my C: drive
Related error is: error building code: error finding mains: unable to get relative path: Rel: can't make C:\\Users\\tryy3\\AppData\\Local\\Temp\\sandbox578858875\\main.go relative to D:\\Codes\\Golang\\src\\github.com\\tryy3\\joyplayground\\sandbox

* The command "joy" is already an existing command on windows that opens the "Game controller" application, there is probably not much to do about this issue other than maybe an alias or a note on the README?