### PR TITLE
Fixed bad fmt.Fprintf at 'joy serve'

### DIFF
--- a/api/serve/serve.go
+++ b/api/serve/serve.go
@@ -151,7 +151,7 @@ func Serve(cfg *Config) error {
 		bundleLock.RLock()
 		src := bundle
 		bundleLock.RUnlock()
-		fmt.Fprintf(w, src)
+		fmt.Fprint(w, src)
 	})
 
 	server := &http.Server{


### PR DESCRIPTION
## Fixed bug.
'joy serve' couldn't use '%' in source code.

```
-		fmt.Fprintf(w, src)
+		fmt.Fprint(w, src)
```

## Example of issue
joy.go

```
if n%3 == 0 {
	return "Fizz"
}
```

http://localhost:8080/bundle.js

```
if (n %! (MISSING)== 0) {
	return "Fizz";
};
```